### PR TITLE
Added v12 to Angular Core in RU local

### DIFF
--- a/src/app/locales/ru_RU.ts
+++ b/src/app/locales/ru_RU.ts
@@ -541,7 +541,7 @@ const steps: LocalizedSteps = {
 
   'v12 ng update': {
     action:
-      'Запустите `npx @angular/cli@12 update @angular/core@ @angular/cli@12`, что должно привести вас к версии 12 Angular.',
+      'Запустите `npx @angular/cli@12 update @angular/core@12 @angular/cli@12`, что должно привести вас к версии 12 Angular.',
   },
   // 'update @ angular / material': { action: 'Run `npx @ angular / cli @ 12 update @ angular / material @ 12`.' },
   'v12 versions': {


### PR DESCRIPTION
There was no version for `@angular/core` in Russian locale, which created errors when updating to Angular 12